### PR TITLE
fix: 🐛fixed duplicate reload

### DIFF
--- a/after/ftplugin/gitcommit.lua
+++ b/after/ftplugin/gitcommit.lua
@@ -1,2 +1,4 @@
-require('cmp').register_source('conventionalcommits',
-                               require('cmp-conventionalcommits').new())
+if vim.g.cmp_conventionalcommits_source_id ~= nil then
+    require('cmp').unregister_source(vim.g.cmp_conventionalcommits_source_id)
+end
+vim.g.cmp_conventionalcommits_source_id = require('cmp').register_source('conventionalcommits', require('cmp-conventionalcommits').new())


### PR DESCRIPTION
Fixed a bug that prevented the original source from being unloaded when opening a gitcommit file multiple times.